### PR TITLE
Initialize Solana memecoin scalper project skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual environments
+venv/
+ENV/
+
+# Pytest cache
+.pytest_cache/
+
+# Environment files
+.env
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
-# git_test
-"Hello Odin!"
+# Memecoin Scalper
+
+This repository contains boilerplate code and file structure for a Solana-based
+memecoin scalping bot. The bot scans for trending, high-volume tokens and aims
+to enter and exit positions for 20-30% profit targets automatically.
+
+## Structure
+
+- `src/memecoin_scalper/` – Core package containing configuration, strategy,
+  and trading logic stubs.
+- `scripts/` – Executable scripts, including `run_bot.py` to trigger a single
+  trading cycle.
+- `tests/` – Pytest-based tests verifying basic behaviour.
+- `requirements.txt` – Python dependencies required for development.
+
+## Running
+
+```bash
+pip install -r requirements.txt
+python scripts/run_bot.py
+```
+
+This project is a starting point; real-world trading requires additional error
+handling, risk management, and infrastructure components.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests>=2.0
+solana>=0.30.0
+pytest

--- a/scripts/run_bot.py
+++ b/scripts/run_bot.py
@@ -1,0 +1,13 @@
+"""Entry point for running the scalping bot."""
+from memecoin_scalper.config import Config
+from memecoin_scalper.trader import ScalpTrader
+
+
+def main() -> None:
+    config = Config()
+    trader = ScalpTrader(config)
+    trader.run_cycle()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/memecoin_scalper/__init__.py
+++ b/src/memecoin_scalper/__init__.py
@@ -1,0 +1,3 @@
+"""Core package for Solana memecoin scalping bot."""
+
+__all__ = ["config", "trending", "trader", "execution", "strategies"]

--- a/src/memecoin_scalper/config.py
+++ b/src/memecoin_scalper/config.py
@@ -1,0 +1,19 @@
+"""Configuration settings for the scalping bot."""
+from dataclasses import dataclass
+
+
+@dataclass
+class Config:
+    """Runtime configuration for the trader.
+
+    Attributes:
+        rpc_endpoint: URL for the Solana RPC node.
+        wallet_secret: Path to the wallet's secret key file.
+        profit_target: Target profit percentage per trade (0.20 -> 20%).
+        max_slippage: Maximum allowed slippage during order execution.
+    """
+
+    rpc_endpoint: str = "https://api.mainnet-beta.solana.com"
+    wallet_secret: str = "~/.config/solana/id.json"
+    profit_target: float = 0.25  # 25% profit target
+    max_slippage: float = 0.01   # 1% slippage

--- a/src/memecoin_scalper/execution.py
+++ b/src/memecoin_scalper/execution.py
@@ -1,0 +1,28 @@
+"""Execution utilities for interacting with the Solana blockchain."""
+from dataclasses import dataclass
+from typing import Any
+
+# Placeholder import for a real Solana client, e.g. from solana.rpc.async_api import AsyncClient
+
+
+@dataclass
+class Order:
+    token: str
+    amount: float
+    side: str  # "buy" or "sell"
+
+
+class SolanaClient:
+    """Simplified client wrapper for submitting orders."""
+
+    def __init__(self, rpc_endpoint: str) -> None:
+        self.rpc_endpoint = rpc_endpoint
+        # self.client = AsyncClient(rpc_endpoint)
+
+    def submit_order(self, order: Order) -> Any:
+        """Submit an order to the blockchain.
+
+        This stub simply returns a placeholder response.
+        """
+        # In production, this would call the actual Solana client.
+        return {"status": "submitted", "order": order}

--- a/src/memecoin_scalper/strategies.py
+++ b/src/memecoin_scalper/strategies.py
@@ -1,0 +1,19 @@
+"""Trading strategy logic."""
+from dataclasses import dataclass
+
+
+@dataclass
+class MarketData:
+    price: float
+    volume_24h: float
+
+
+def should_enter(data: MarketData, profit_target: float) -> bool:
+    """Determine whether to enter a position."""
+    # Placeholder logic: enter if volume is high; real logic would be more complex
+    return data.volume_24h > 1_000_000
+
+
+def should_exit(entry_price: float, current_price: float, profit_target: float) -> bool:
+    """Determine whether to exit a position."""
+    return current_price >= entry_price * (1 + profit_target)

--- a/src/memecoin_scalper/trader.py
+++ b/src/memecoin_scalper/trader.py
@@ -1,0 +1,57 @@
+"""Main trading engine for the scalping bot."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+from .config import Config
+from .execution import Order, SolanaClient
+from .strategies import MarketData, should_enter, should_exit
+from .trending import fetch_trending_tokens
+
+
+@dataclass
+class Position:
+    token: str
+    amount: float
+    entry_price: float
+
+
+class ScalpTrader:
+    """High-level orchestration of the scalping strategy."""
+
+    def __init__(self, config: Config) -> None:
+        self.config = config
+        self.client = SolanaClient(config.rpc_endpoint)
+        self.positions: List[Position] = []
+
+    def run_cycle(self) -> None:
+        """Execute a single trading cycle."""
+        for symbol in fetch_trending_tokens():
+            market_data = self._get_market_data(symbol)
+            if should_enter(market_data, self.config.profit_target):
+                self._enter_position(symbol, market_data.price)
+
+        for position in list(self.positions):
+            current_price = self._get_market_price(position.token)
+            if should_exit(position.entry_price, current_price, self.config.profit_target):
+                self._exit_position(position, current_price)
+
+    # --- Internal helpers -------------------------------------------------
+    def _get_market_data(self, symbol: str) -> MarketData:
+        # Placeholder for fetching price/volume data
+        return MarketData(price=1.0, volume_24h=2_000_000)
+
+    def _get_market_price(self, symbol: str) -> float:
+        # Placeholder for getting the current market price
+        return 1.25
+
+    def _enter_position(self, symbol: str, price: float) -> None:
+        order = Order(token=symbol, amount=1.0, side="buy")
+        self.client.submit_order(order)
+        self.positions.append(Position(token=symbol, amount=1.0, entry_price=price))
+
+    def _exit_position(self, position: Position, price: float) -> None:
+        order = Order(token=position.token, amount=position.amount, side="sell")
+        self.client.submit_order(order)
+        self.positions.remove(position)

--- a/src/memecoin_scalper/trending.py
+++ b/src/memecoin_scalper/trending.py
@@ -1,0 +1,26 @@
+"""Utilities for discovering trending tokens."""
+from typing import List
+
+import requests
+
+API_URL = "https://api.example.com/trending"  # placeholder
+
+
+def fetch_trending_tokens(limit: int = 10) -> List[str]:
+    """Fetch a list of trending token symbols.
+
+    Args:
+        limit: Maximum number of tokens to return.
+
+    Returns:
+        A list of token mint addresses or symbols.
+    """
+    # This is a stub using a hypothetical API response.
+    try:
+        response = requests.get(API_URL, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+        return [token["symbol"] for token in data["tokens"]][:limit]
+    except Exception:
+        # In production, log the error. For now, return an empty list.
+        return []

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,6 @@
+from memecoin_scalper.config import Config
+
+
+def test_default_profit_target() -> None:
+    cfg = Config()
+    assert 0 < cfg.profit_target < 1


### PR DESCRIPTION
## Summary
- scaffold memecoin scalping bot for Solana with configurable profit targets and slippage
- add trending token discovery, strategy hooks, and trading engine stubs
- include run script, requirements, and basic pytest

## Testing
- `PYTHONPATH=src python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689799394b40832c8ce6aae587cc5a5a